### PR TITLE
dataset: fix DatasetInfo urls argument

### DIFF
--- a/bdlb/diabetic_retinopathy_diagnosis/tfds_adapter.py
+++ b/bdlb/diabetic_retinopathy_diagnosis/tfds_adapter.py
@@ -98,7 +98,7 @@ class DiabeticRetinopathyDiagnosis(tfds.image.DiabeticRetinopathyDetection):
             "label":
             tfds.features.ClassLabel(num_classes=2),
         }),
-        urls=["https://www.kaggle.com/c/diabetic-retinopathy-detection/data"],
+        homepage="https://www.kaggle.com/c/diabetic-retinopathy-detection/data",
         citation=tfds.image.diabetic_retinopathy_detection._CITATION,
     )
 

--- a/bdlb/fishyscapes/fishyscapes_tfds.py
+++ b/bdlb/fishyscapes/fishyscapes_tfds.py
@@ -78,7 +78,7 @@ class Fishyscapes(tfds.core.GeneratorBasedBuilder):
         }),
         supervised_keys=('image_left', 'mask'),
         # Homepage of the dataset for documentation
-        urls=[],
+        homepage='https://fishyscapes.com/',
         citation=_CITATION,
     )
 


### PR DESCRIPTION
Constructor of `tensorflow_datasets.core.DatasetInfo` does not have an argument `urls`, passing it causes an error.
```
bdlb/fishyscapes/fishyscapes_tfds.py in _info(self)
	TypeError: __init__() got an unexpected keyword argument 'urls'
```
I fix it by changing `urls` to `homepage` argument name.
